### PR TITLE
refactor(get_redis_clients): move this functionality to a central location

### DIFF
--- a/backend/services/redis.py
+++ b/backend/services/redis.py
@@ -3,39 +3,14 @@
 import json
 import logging
 
-import redis
 from fastapi import HTTPException, status
 
-from backend.config import settings
+from backend.services.redis_client import get_redis_cache_client, get_redis_queue_client
 from backend.utils import is_song_in_queue, is_track_object
 
 logger = logging.getLogger(__name__)
 
 CACHE_TTL = 21600
-
-
-def get_redis_queue_client():
-    """Lazy initialization of the Redis queue client.
-
-    Returns:
-        A Redis queue client.
-    """
-    if not hasattr(get_redis_queue_client, "client"):
-        get_redis_queue_client.client = redis.StrictRedis.from_url(settings.redis_url, db=0, decode_responses=True)
-
-    return get_redis_queue_client.client
-
-
-def get_redis_cache_client():
-    """Lazy initialization of the Redis cache client.
-
-    Returns:
-        A redis cache client.
-    """
-    if not hasattr(get_redis_cache_client, "client"):
-        get_redis_cache_client.client = redis.StrictRedis.from_url(settings.redis_url, db=1, decode_responses=True)
-
-    return get_redis_cache_client.client
 
 
 def add_to_queue_redis(song):

--- a/backend/services/redis_client.py
+++ b/backend/services/redis_client.py
@@ -1,0 +1,27 @@
+"""Handle lazily creating redis clients in a central location."""
+
+import redis
+
+from backend.config import settings
+
+
+def get_redis_queue_client():
+    """Lazy initialization of the Redis queue client.
+
+    Returns:
+        A Redis queue client.
+    """
+    if not hasattr(get_redis_queue_client, "client"):
+        get_redis_queue_client.client = redis.StrictRedis.from_url(settings.redis_url, db=0, decode_responses=True)
+    return get_redis_queue_client.client
+
+
+def get_redis_cache_client():
+    """Lazy initialization of the Redis cache client.
+
+    Returns:
+        A Redis cache client.
+    """
+    if not hasattr(get_redis_cache_client, "client"):
+        get_redis_cache_client.client = redis.StrictRedis.from_url(settings.redis_url, db=1, decode_responses=True)
+    return get_redis_cache_client.client

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -50,7 +50,7 @@ def mock_redis(mocker, mock_settings):
     mock_redis_queue = MagicMock()
     mock_redis_cache = MagicMock()
 
-    mocker.patch("backend.services.redis.get_redis_queue_client", return_value=mock_redis_queue)
-    mocker.patch("backend.services.redis.get_redis_cache_client", return_value=mock_redis_cache)
+    mocker.patch("backend.services.redis_client.get_redis_queue_client", return_value=mock_redis_queue)
+    mocker.patch("backend.services.redis_client.get_redis_cache_client", return_value=mock_redis_cache)
 
     return mock_redis_queue, mock_redis_cache

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -23,7 +23,7 @@ def tracker():
     return TrackTimeTracker()
 
 
-@patch("backend.services.redis.redis.StrictRedis.from_url")
+@patch("backend.services.redis_client.redis.StrictRedis.from_url")
 def test_get_redis_queue_client(mock_redis):
     """Test the lazy initialization of Redis client."""
     mock_redis_queue = MagicMock()

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -49,6 +49,7 @@ def test_song_found_in_queue(mock_redis, mock_plex_track):
     mock_redis_queue, _ = mock_redis
     with patch("backend.utils.get_redis_queue_client", return_value=mock_redis_queue):
         mock_redis_queue.lrange.return_value = ['{"item_id": "12345", "title": "Mock Song", "artist": "Mock Artist"}']
+
         assert is_song_in_queue(mock_plex_track) is True
         mock_redis_queue.lrange.assert_called_once_with("playback_queue", 0, -1)
 
@@ -56,7 +57,7 @@ def test_song_found_in_queue(mock_redis, mock_plex_track):
 def test_song_not_in_queue(mock_redis, mock_plex_track):
     """Test when a song is not in the queue."""
     mock_redis_queue, _ = mock_redis
-    with patch("backend.utils.get_redis_queue_client", return_value=mock_redis_queue):
+    with patch("backend.services.redis_client.get_redis_queue_client", return_value=mock_redis_queue):
         mock_redis_queue.lrange.return_value = [
             '{"item_id": "67890", "title": "Different Song", "artist": "Different Artist"}'
         ]
@@ -66,7 +67,7 @@ def test_song_not_in_queue(mock_redis, mock_plex_track):
 def test_empty_queue(mock_redis, mock_plex_track):
     """Test behavior with an empty queue."""
     mock_redis_queue, _ = mock_redis
-    with patch("backend.utils.get_redis_queue_client", return_value=mock_redis_queue):
+    with patch("backend.services.redis_client.get_redis_queue_client", return_value=mock_redis_queue):
         mock_redis_queue.lrange.return_value = []
         assert is_song_in_queue(mock_plex_track) is False
 

--- a/backend/tests/test_websockets.py
+++ b/backend/tests/test_websockets.py
@@ -180,7 +180,8 @@ async def test_send_queue(mock_queue, mock_redis):
     mock_redis_queue, _ = mock_redis
     mock_redis_queue.lrange.return_value = [json.dumps(item) for item in mock_queue]
 
-    await send_queue()
+    with patch("backend.services.redis.get_redis_queue_client", return_value=mock_redis_queue):
+        await send_queue()
 
     assert len(mock_ws.sent_messages) == 1
     sent_data = json.loads(mock_ws.sent_messages[0])

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -3,22 +3,9 @@
 import json
 import time
 
-import redis
 from plexapi.audio import Track
 
-from backend.config import settings
-
-
-def get_redis_queue_client():
-    """Lazy initialization of the Redis queue client.
-
-    Returns:
-        A Redis queue client.
-    """
-    if not hasattr(get_redis_queue_client, "client"):
-        get_redis_queue_client.client = redis.StrictRedis.from_url(settings.redis_url, db=0, decode_responses=True)
-
-    return get_redis_queue_client.client
+from backend.services.redis_client import get_redis_queue_client
 
 
 def is_track_object(item):


### PR DESCRIPTION
Closes #39 

this means we can stop writing the same code in two files while also avoiding circular imports. it also turned out to be a bit easier than expected.